### PR TITLE
Add Slalom Build capability to capability catalog

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -101,6 +101,15 @@ capabilities = {
         "industry_verticals": ["Technology", "Financial Services", "Healthcare"],
         "capacity": 20,
         "consultants": ["charlotte.young@slalom.com", "henry.king@slalom.com"]
+    },
+    "Slalom Build": {
+        "description": "Product strategy, design thinking, and agile product development for digital innovation",
+        "practice_area": "Technology",
+        "skill_levels": ["Emerging", "Proficient", "Advanced", "Expert"],
+        "certifications": ["Certified Scrum Product Owner", "Pragmatic Product Management", "ICAgile Product Management"],
+        "industry_verticals": ["Consumer Products", "FinTech", "HealthTech"],
+        "capacity": 28,
+        "consultants": ["marcus.taylor@slalom.com", "zoe.nguyen@slalom.com"]
     }
 }
 


### PR DESCRIPTION
## Summary
Adds the missing **Slalom Build** capability requested in issue #6.

## Changes
- Added a new `Slalom Build` entry to the in-memory `capabilities` dictionary in `src/app.py`
- Included requested capability metadata:
  - Skill levels (`Emerging` through `Expert`)
  - Product-focused certifications
  - Industry vertical mappings (`Consumer Products`, `FinTech`, `HealthTech`)
  - Initial team capacity and starter consultant registrations

## Why
Issue #6 calls out an immediate business need for client proposals requiring Slalom Build expertise.

Closes #6